### PR TITLE
renderer did not work for me due to invalid less parser option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var less = require('less'),
 
 hexo.extend.renderer.register('less', 'css', function(data, options, callback){
   var parser = new less.Parser({
-    paths: path.dirname(data.path),
+    paths: [path.dirname(data.path)],
     filename: path.basename(data.path)
   });
 


### PR DESCRIPTION
The renderer did not work for me (OSX 10.8) due to an invalid less.Parser option. The search path for imports should be an array, was a string.

see: http://lesscss.org/#using-less-configuration
