### PR TITLE
Less include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ $ npm install hexo-renderer-less --save
 ```
 
 [Less]: http://lesscss.org/
+
+## Configure
+
+You can specify a [less include paths](http://lesscss.org/usage/#command-line-usage-include-paths) as an array config in your theme configuration.
+
+```yaml
+// themes/yourtheme/_config.yml
+
+less:
+  paths:
+    - bower_components/bootstrap/less
+```

--- a/index.js
+++ b/index.js
@@ -2,8 +2,14 @@ var less = require('less'),
   path = require('path');
 
 hexo.extend.renderer.register('less', 'css', function(data, options, callback){
+  var themeConfig = this.hexo.theme.config.less || {};
+  var cwd = process.cwd();
+    var paths = (themeConfig.paths || []).map(function(filepath){
+    return path.join(cwd, filepath);    // assuming paths are relative from the root of the project
+  });
+
   var parser = new less.Parser({
-    paths: [path.dirname(data.path)],
+    paths: paths.concat(path.dirname(data.path)),
     filename: path.basename(data.path)
   });
 


### PR DESCRIPTION
This change enables to specify Less include paths items.

``` yaml
// themes/yourtheme/_config.yml

less:
  paths:
    - bower_components/bootstrap/less
```

And then doing the following will lookup first in the import paths:

``` css
// in themes/yourtheme/source/stylesheets/main.less
@import 'bootstrap.less';

// ...
```

Included that way:

``` ejs
<%- css(['stylesheets/main.css']) %>
```
