### PR TITLE
master

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var less = require('less'),
   path = require('path');
 
 hexo.extend.renderer.register('less', 'css', function(data, options, callback){
-  var themeConfig = this.hexo.theme.config.less || {};
+  var themeConfig = hexo.theme.config.less || {};
   var cwd = process.cwd();
     var paths = (themeConfig.paths || []).map(function(filepath){
     return path.join(cwd, filepath);    // assuming paths are relative from the root of the project


### PR DESCRIPTION
Compatibility with Hexo 3 beta

When using the renderer with Hexo3 beta, the following error occurs:

    ERROR Asset render failed: css/components.css
    TypeError: Cannot read property 'theme' of undefined
    at Hexo.<anonymous> (D:\Develop\NopileosLog\node_modules\hexo-renderer-less\index.js:5:30)
    at Hexo.tryCatcher (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\util.js:24:31)
    at Hexo.ret (eval at <anonymous> (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\promisify.js:154:12), <anonymous>:13:39)
    at C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\lib\hexo\render.js:51:21
    at tryCatcher (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\util.js:24:31)
    at Promise._settlePromiseFromHandler (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\promise.js:466:31)
    at Promise._settlePromiseAt(C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\promise.js:545:18)
    at Promise._settlePromises (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\promise.js:661:14)
    at Async._drainQueue (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\async.js:79:16)
    at Async._drainQueues (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\async.js:89:10)
    at Immediate.Async.drainQueues [as _onImmediate] (C:\Users\SebastianP.R\AppData\Roaming\npm\node_modules\hexo\node_modules\bluebird\js\main\async.js:14:14)
    at processImmediate [as _immediateCallback] (timers.js:358:17)

It seems 'this.hexo' is undefined. When omitting the 'this', hexo is found, and the less renderer works again. So here is a pull request for this issue.

Perhaps there's a better solution, but this works for me.