### PR TITLE
refactor: move renderer to lib/ & drop 'compress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,16 @@ $ npm install hexo-renderer-less --save
 
 ## Configure
 
-You can specify a [less include paths](http://lesscss.org/usage/#less-options-include-paths) as an array config in your theme configuration.
+In your theme configuration,
 
 ```yaml
 // themes/yourtheme/_config.yml
 
 less:
-  paths:
-    - bower_components/bootstrap/less
+  paths: []
 ```
 
-You can compress the output of the css with a config in your theme configuration.
-
-```yaml
-// themes/yourtheme/_config.yml
-
-less:
-  compress: true
-```
+- **paths**: Array of [include paths](http://lesscss.org/usage/#less-options-include-paths).
+  * e.g. to include Bower Bootstrap, `['bower_components/bootstrap/less']`
 
 [Less]: http://lesscss.org/

--- a/index.js
+++ b/index.js
@@ -1,21 +1,5 @@
 /* global hexo */
+
 'use strict';
 
-const less = require('less');
-const path = require('path');
-
-hexo.extend.renderer.register('less', 'css', async(data) => {
-  const themeConfig = hexo.theme.config.less || {};
-  const cwd = process.cwd();
-  const paths = (themeConfig.paths || []).map(filepath => {
-    return path.join(cwd, filepath); // assuming paths are relative from the root of the project
-  });
-
-  const result = await less.render(data.text, {
-    paths: paths.concat(path.dirname(data.path)),
-    filename: path.basename(data.path),
-    compress: themeConfig.compress || false
-  });
-
-  return result.css;
-});
+hexo.extend.renderer.register('less', 'css', require('./lib/renderer'));

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -5,8 +5,7 @@ const { basename, dirname, join} = require('path');
 
 module.exports = async function(data) {
   this.theme.config.less = Object.assign({
-    paths: [],
-    compress: false
+    paths: []
   }, this.theme.config.less);
 
   const config = this.theme.config.less;
@@ -17,8 +16,7 @@ module.exports = async function(data) {
 
   const result = await less.render(data.text, {
     paths: paths.concat(dirname(data.path)),
-    filename: basename(data.path),
-    compress: config.compress
+    filename: basename(data.path)
   });
 
   return result.css;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const less = require('less');
-const path = require('path');
+const { basename, dirname, join} = require('path');
 
 module.exports = async function(data) {
   this.theme.config.less = Object.assign({
@@ -12,12 +12,12 @@ module.exports = async function(data) {
   const config = this.theme.config.less;
   const cwd = process.cwd();
   const paths = config.paths.map(filepath => {
-    return path.join(cwd, filepath); // assuming paths are relative from the root of the project
+    return join(cwd, filepath); // assuming paths are relative from the root of the project
   });
 
   const result = await less.render(data.text, {
-    paths: paths.concat(path.dirname(data.path)),
-    filename: path.basename(data.path),
+    paths: paths.concat(dirname(data.path)),
+    filename: basename(data.path),
     compress: config.compress
   });
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const less = require('less');
+const path = require('path');
+
+module.exports = async function(data) {
+  this.theme.config.less = Object.assign({
+    paths: [],
+    compress: false
+  }, this.theme.config.less);
+
+  const config = this.theme.config.less;
+  const cwd = process.cwd();
+  const paths = config.paths.map(filepath => {
+    return path.join(cwd, filepath); // assuming paths are relative from the root of the project
+  });
+
+  const result = await less.render(data.text, {
+    paths: paths.concat(path.dirname(data.path)),
+    filename: path.basename(data.path),
+    compress: config.compress
+  });
+
+  return result.css;
+};

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "1.0.0",
   "description": "Less renderer plugin for Hexo",
   "main": "index.js",
+  "directories": {
+    "lib": "./lib"
+  },
   "files": [
-    "index.js"
+    "index.js",
+    "lib/"
   ],
   "scripts": {
     "eslint": "eslint ."


### PR DESCRIPTION
Move function to `lib/` folder to make way for unit test (requires `module.exports`).

`compress` has been [deprecated](http://lesscss.org/usage/#less-options).