### PR TITLE
ci(travis): add windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ node_js:
   - "node"
 
 script:
-  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-      git config core.autocrlf false && git add --renormalize . && git reset --hard;
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then
+      npm run eslint;
     fi
-  - npm run eslint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - windows
+
 language: node_js
 
 sudo: false
@@ -11,4 +15,7 @@ node_js:
   - "node"
 
 script:
+  - if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+      git config core.autocrlf false && git add --renormalize . && git reset --hard;
+    fi
   - npm run eslint


### PR DESCRIPTION
Enable windows build on Travis.

Follow the guide in https://travis-ci.community/t/provide-git-config-forcrlf/3307 to avoid eslint crlf check failure.